### PR TITLE
Implement Supabase persistence for form builder

### DIFF
--- a/.env.example
+++ b/.env.example
@@ -1,7 +1,7 @@
-# Supabase configuration
+# Supabase project configuration
 NEXT_PUBLIC_SUPABASE_URL=
 NEXT_PUBLIC_SUPABASE_ANON_KEY=
 SUPABASE_SERVICE_ROLE_KEY=
 
-# Application metadata
+# Public URL of the deployed application
 NEXT_PUBLIC_SITE_URL=

--- a/README.md
+++ b/README.md
@@ -1,14 +1,79 @@
-# Firebase Studio
+# FirebaseFormulário
 
-This is a NextJS starter in Firebase Studio.
+Aplicativo de formulários construído com Next.js 15, Tailwind CSS e Supabase. Ele permite que você crie projetos, defina destinatários e acompanhe respostas diretamente no banco de dados do Supabase.
 
-To get started, take a look at `src/app/page.tsx`.
+## Como começar
 
-## Environment variables
+1. Instale as dependências:
+   ```bash
+   npm install
+   ```
+2. Copie o arquivo `.env.example` para `.env.local` e preencha os valores necessários:
+   ```bash
+   cp .env.example .env.local
+   ```
+3. Execute o servidor de desenvolvimento:
+   ```bash
+   npm run dev
+   ```
+   O app ficará disponível em `http://localhost:9002` por padrão.
 
-Copy the `.env.example` file to `.env.local` and fill in the values before running the project locally:
+## Configuração do Supabase
 
-- `NEXT_PUBLIC_SUPABASE_URL` – URL for your Supabase project.
-- `NEXT_PUBLIC_SUPABASE_ANON_KEY` – public anonymous key from Supabase used by the browser client.
-- `SUPABASE_SERVICE_ROLE_KEY` – service role key used for server-side operations.
-- `NEXT_PUBLIC_SITE_URL` – public URL where the site will be available.
+O projeto utiliza três tabelas principais no Supabase:
+
+- **projects**
+  - `id` (`uuid`, chave primária, `default uuid_generate_v4()`)
+  - `project_name` (`text`)
+  - `client_name` (`text`)
+  - `status` (`text`, valores esperados: `rascunho`, `em_andamento`, `concluido`)
+  - `notification` (`jsonb`, opcional)
+  - `created_at` (`timestamptz`, `default now()`)
+  - `updated_at` (`timestamptz`, atualizado via trigger)
+
+- **recipients**
+  - `id` (`uuid`, chave primária)
+  - `project_id` (`uuid`, referência para `projects.id`)
+  - `name` (`text`)
+  - `position` (`text`)
+  - `email` (`text`)
+  - `status` (`text`, valores esperados: `pendente`, `enviado`, `concluido`)
+  - `questions` (`jsonb`, array de IDs de perguntas)
+  - `created_at` (`timestamptz`, `default now()`)
+  - `updated_at` (`timestamptz`, atualizado via trigger)
+
+- **submissions**
+  - `id` (`uuid`, chave primária, `default uuid_generate_v4()`)
+  - `project_id` (`uuid`, referência para `projects.id`)
+  - `recipient_id` (`uuid`, referência para `recipients.id`)
+  - `answers` (`jsonb`)
+  - `created_at` (`timestamptz`, `default now()`)
+
+Habilite o Row Level Security (RLS) e crie policies adequadas para acessos públicos, se necessário. As _server actions_ utilizam a `SUPABASE_SERVICE_ROLE_KEY`, portanto conseguem realizar mutações mesmo com RLS ativo.
+
+## Variáveis de ambiente
+
+| Variável | Descrição |
+| --- | --- |
+| `NEXT_PUBLIC_SUPABASE_URL` | URL do seu projeto Supabase. |
+| `NEXT_PUBLIC_SUPABASE_ANON_KEY` | Chave pública (anon) do Supabase utilizada no cliente. |
+| `SUPABASE_SERVICE_ROLE_KEY` | Chave de service role usada pelas _server actions_ para mutações seguras. |
+| `NEXT_PUBLIC_SITE_URL` | URL pública da aplicação (utilizada em links gerados no app). |
+
+## Funcionalidades principais
+
+- Persistência de projetos, destinatários e perguntas diretamente no Supabase através de _server actions_.
+- Atualização granular de perguntas por destinatário com a rota `/api/projects/[id]` disponível para carregamento direto via URL.
+- Registro de envios dos destinatários e geração de aviso automatizado quando todos completam as respostas.
+
+## Scripts úteis
+
+- `npm run dev` – inicia o servidor de desenvolvimento.
+- `npm run build` – gera o build de produção do Next.js.
+- `npm run start` – inicia o servidor de produção local.
+- `npm run lint` – executa o lint do Next.js.
+- `npm run typecheck` – valida os tipos TypeScript.
+
+## Deploy
+
+O projeto pode ser implantado na Vercel. Certifique-se de replicar todas as variáveis de ambiente no painel da Vercel e garanta que a `SUPABASE_SERVICE_ROLE_KEY` seja configurada apenas como variável de ambiente de servidor.

--- a/src/app/api/projects/[id]/route.ts
+++ b/src/app/api/projects/[id]/route.ts
@@ -1,0 +1,17 @@
+import { NextResponse } from 'next/server';
+import { fetchProjectWithRecipients } from '@/lib/supabase/projects';
+
+export async function GET(_request: Request, { params }: { params: { id: string } }) {
+  try {
+    const project = await fetchProjectWithRecipients(params.id);
+
+    if (!project) {
+      return NextResponse.json({ error: 'Projeto não encontrado.' }, { status: 404 });
+    }
+
+    return NextResponse.json({ project });
+  } catch (error) {
+    console.error('Failed to load project:', error);
+    return NextResponse.json({ error: 'Falha ao carregar o projeto.' }, { status: 500 });
+  }
+}

--- a/src/lib/supabase/projects.ts
+++ b/src/lib/supabase/projects.ts
@@ -1,0 +1,150 @@
+import { supabaseServer } from "./server";
+import type { Project, ProjectStatus, Recipient, RecipientStatus } from "@/types";
+import type { JsonArray } from "@/types";
+
+export interface RecipientRow {
+  id: string;
+  project_id: string;
+  name: string;
+  position: string;
+  email: string;
+  status: RecipientStatus | null;
+  questions: unknown;
+}
+
+interface ProjectRow {
+  id: string;
+  project_name: string;
+  client_name: string;
+  status: ProjectStatus | null;
+  notification: unknown;
+  recipients?: RecipientRow[] | null;
+}
+
+export interface SubmissionRow {
+  id: string;
+  project_id: string;
+  recipient_id: string;
+  answers: unknown;
+}
+
+export const sanitizeQuestions = (value: unknown): string[] => {
+  if (!Array.isArray(value)) {
+    return [];
+  }
+
+  const uniqueValues = new Set<string>();
+  for (const item of value) {
+    if (typeof item === "string") {
+      uniqueValues.add(item);
+    }
+  }
+
+  return Array.from(uniqueValues);
+};
+
+const parseNotification = (value: unknown): Project["notification"] => {
+  if (!value || typeof value !== "object") {
+    return undefined;
+  }
+
+  const record = value as Record<string, unknown>;
+  const message = typeof record.message === "string" ? record.message : undefined;
+  const isComprehensive = typeof record.isComprehensive === "boolean" ? record.isComprehensive : false;
+
+  if (!message) {
+    return undefined;
+  }
+
+  return {
+    message,
+    isComprehensive,
+  };
+};
+
+export const mapRecipientRow = (row: RecipientRow): Recipient => ({
+  id: row.id,
+  name: row.name,
+  position: row.position,
+  email: row.email,
+  status: (row.status ?? "pendente") as RecipientStatus,
+  questions: sanitizeQuestions(row.questions) as JsonArray,
+});
+
+export const mapProjectRow = (row: ProjectRow): Project => ({
+  id: row.id,
+  projectName: row.project_name,
+  clientName: row.client_name,
+  status: (row.status ?? "rascunho") as ProjectStatus,
+  recipients: (row.recipients ?? []).map(mapRecipientRow),
+  notification: parseNotification(row.notification),
+});
+
+export async function fetchProjectWithRecipients(projectId: string): Promise<Project | null> {
+  const supabase = supabaseServer();
+
+  const { data, error } = await supabase
+    .from("projects")
+    .select(
+      `id, project_name, client_name, status, notification, recipients (id, project_id, name, position, email, status, questions)`
+    )
+    .eq("id", projectId)
+    .maybeSingle();
+
+  if (error) {
+    throw new Error(`Failed to fetch project: ${error.message}`);
+  }
+
+  if (!data) {
+    return null;
+  }
+
+  return mapProjectRow(data as ProjectRow);
+}
+
+export async function fetchRecipientsByProjectId(projectId: string): Promise<RecipientRow[]> {
+  const supabase = supabaseServer();
+
+  const { data, error } = await supabase
+    .from("recipients")
+    .select("id, project_id, name, position, email, status, questions")
+    .eq("project_id", projectId);
+
+  if (error) {
+    throw new Error(`Failed to fetch recipients: ${error.message}`);
+  }
+
+  return (data as RecipientRow[]) ?? [];
+}
+
+export async function fetchRecipientById(projectId: string, recipientId: string): Promise<RecipientRow | null> {
+  const supabase = supabaseServer();
+
+  const { data, error } = await supabase
+    .from("recipients")
+    .select("id, project_id, name, position, email, status, questions")
+    .eq("project_id", projectId)
+    .eq("id", recipientId)
+    .maybeSingle();
+
+  if (error) {
+    throw new Error(`Failed to fetch recipient: ${error.message}`);
+  }
+
+  return (data as RecipientRow) ?? null;
+}
+
+export async function fetchSubmissionsByProjectId(projectId: string): Promise<SubmissionRow[]> {
+  const supabase = supabaseServer();
+
+  const { data, error } = await supabase
+    .from("submissions")
+    .select("id, project_id, recipient_id, answers")
+    .eq("project_id", projectId);
+
+  if (error) {
+    throw new Error(`Failed to fetch submissions: ${error.message}`);
+  }
+
+  return (data as SubmissionRow[]) ?? [];
+}

--- a/src/types/supabase-js.d.ts
+++ b/src/types/supabase-js.d.ts
@@ -1,0 +1,20 @@
+declare module '@supabase/supabase-js' {
+  export interface SupabaseClient<Database = any> {
+    from: (table: string) => any;
+    auth: any;
+  }
+
+  export interface SupabaseClientOptions {
+    auth?: {
+      persistSession?: boolean;
+      autoRefreshToken?: boolean;
+      detectSessionInUrl?: boolean;
+    };
+  }
+
+  export function createClient<Database = any>(
+    supabaseUrl: string,
+    supabaseKey: string,
+    options?: SupabaseClientOptions
+  ): SupabaseClient<Database>;
+}


### PR DESCRIPTION
## Summary
- replace the mock server actions with Supabase-backed CRUD for projects, recipients, questions, and submissions
- add Supabase query helpers and a GET /api/projects/[id] route to load projects directly from the database
- load project data from the new API on the homepage and refresh the Supabase documentation and environment template

## Testing
- npm run typecheck

------
https://chatgpt.com/codex/tasks/task_e_68c8bd9e26848327aa8d713f29232e3b