### PR TITLE
Type Supabase cookie setters

### DIFF
--- a/src/lib/supabase/middleware.ts
+++ b/src/lib/supabase/middleware.ts
@@ -21,7 +21,13 @@ export const createClient = (request: NextRequest) => {
         getAll() {
           return request.cookies.getAll()
         },
-        setAll(cookiesToSet) {
+        setAll(
+          cookiesToSet: {
+            name: string;
+            value: string;
+            options: CookieOptions;
+          }[],
+        ) {
           cookiesToSet.forEach(({ name, value, options }) => request.cookies.set(name, value))
           supabaseResponse = NextResponse.next({
             request,

--- a/src/lib/supabase/server.ts
+++ b/src/lib/supabase/server.ts
@@ -1,6 +1,6 @@
 // utils/supabase/server.ts
 import { createClient as createSupabaseClient, type SupabaseClient } from "@supabase/supabase-js";
-import { createServerClient } from "@supabase/ssr";
+import { createServerClient, type CookieOptions } from "@supabase/ssr";
 import { cookies } from "next/headers";
 // opcional: force server-only
 // import "server-only";
@@ -31,7 +31,13 @@ export const createSSRClient = (cookieStore: ReturnType<typeof cookies>) => {
       getAll() {
         return cookieStore.getAll();
       },
-      setAll(cookiesToSet) {
+      setAll(
+        cookiesToSet: {
+          name: string;
+          value: string;
+          options: CookieOptions;
+        }[],
+      ) {
         try {
           cookiesToSet.forEach(({ name, value, options }) =>
             cookieStore.set(name, value, options)


### PR DESCRIPTION
## Summary
- type the Supabase cookie `setAll` helper in middleware and server utilities to accept typed cookie tuples
- import CookieOptions from `@supabase/ssr` where the typed helpers are defined

## Testing
- `npm run typecheck` *(fails: existing project lacks many type definitions including Next.js and Node globals)*

------
https://chatgpt.com/codex/tasks/task_e_68c94e86b51c83279262549ba6d0b5a3