### PR TITLE
fix(email-token): usa link /responder?token= e remove chamadas /api/recipients no admin-view

### DIFF
--- a/src/lib/esgApi.ts
+++ b/src/lib/esgApi.ts
@@ -53,6 +53,18 @@ export function buildResponderLink(token: string) {
   return `${baseUrl}/responder?token=${encodeURIComponent(token)}`;
 }
 
+export async function getDestinatarioTokenByEmail(projetoId: string, email: string) {
+  const { data, error } = await supabase
+    .from('destinatarios')
+    .select('token')
+    .eq('projeto_id', projetoId)
+    .eq('email', email)
+    .maybeSingle();
+
+  if (error) throw new Error(error.message);
+  return data?.token ?? null;
+}
+
 /** ===== CRUD ===== */
 
 /** ADMIN: cria um projeto */


### PR DESCRIPTION
## Summary
- adiciona helper para buscar token do destinatário por e-mail no esgApi reutilizando o buildResponderLink
- atualiza a tela de administração para preparar e-mails com link baseado no token e atualizar o status somente no estado local
- remove dependências das rotas /api/recipients e garante uso dos utilitários locais no admin-view

## Testing
- npm run typecheck *(falhou: o projeto possui diversos erros de tipagem pré-existentes não relacionados a esta alteração)*

------
https://chatgpt.com/codex/tasks/task_e_68caac3d2b8c8327884234e66e468b86